### PR TITLE
FeatureSort

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -93,8 +93,14 @@
           "ArtistID": {
             "S": "artist1"
           },
+          "AA_PK": {
+            "S": "album1"
+          },
           "AA_SK": {
             "S": "100"
+          },
+          "AC_PK": {
+            "S": "artist1"
           },
           "AC_SK": {
             "S": "100"
@@ -108,11 +114,11 @@
           "TrackTitle": {
             "S": "Taxman"
           },
-          "AA_PK": {
-            "S": "album1"
-          },
           "Featured": {
             "BOOL": true
+          },
+          "FeatureSort": {
+            "S": "100"
           },
           "PK": {
             "S": "track1"
@@ -122,9 +128,6 @@
           },
           "Count": {
             "N": "11"
-          },
-          "AC_PK": {
-            "S": "artist1"
           },
           "AudioURL":{
             "S": "https://..."

--- a/trogs_app/admin/singles.py
+++ b/trogs_app/admin/singles.py
@@ -8,7 +8,11 @@ from . import exceptions, names
 from .models import Artist, Single, parse_release_date
 
 
+# license given to singles upon upload
 DEFAULT_LICENSE = 'by-nc-nd'
+
+# Artist-Content (AC) sort for singles
+DEFAULT_SORT = '300'
 
 
 def item_to_single(item):
@@ -44,7 +48,7 @@ def list_for_artist(artist_id):
         IndexName='IX_ARTIST_CONTENT',
         ScanIndexForward=True,
         KeyConditionExpression=Key('AC_PK').eq(
-            artist_id) & Key('AC_SK').begins_with('3')
+            artist_id) & Key('AC_SK').begins_with(DEFAULT_SORT[0])
     )
     return list(map(item_to_single, res['Items']))
 
@@ -64,7 +68,7 @@ def create(artist, single_title, audio_url):
         last_sort = int(last.sort)
         sort = str(last_sort + 1)
     else:
-        sort = '300'
+        sort = DEFAULT_SORT
 
     single = Single(
         id=ids.new_id(),

--- a/trogs_app/artists.py
+++ b/trogs_app/artists.py
@@ -47,7 +47,7 @@ def map_detail(items):
         'artistId': artist['AC_PK'],
         'name': artist['AA_SK'],
         'image_url': artist.get('ImageURL'),
-        'featured_tracks': list(map(map_track, filter(is_featured, children))),
+        'featured_tracks': sorted(list(map(map_track, filter(is_featured, children))),key = lambda t: t['feature_sort']),
         'albums': list(map(map_album, filter(is_album, children))),
         'singles': list(map(map_track, filter(not_featured, filter(is_single, children))))
     }
@@ -100,6 +100,8 @@ def map_track(item):
     if license:
         track["license"] = license
         track["license_name"] = licenses.names[license]
+
+    track['feature_sort'] = item.get('FeatureSort')
 
     return track
 

--- a/util/data_migrate.py
+++ b/util/data_migrate.py
@@ -43,13 +43,59 @@ def add_artist_normalized_names():
 
 
 def add_feature_sort():
-    
-    # get featured tracks
 
-    #if no FeatureSort attr
+    table = db.get_table()
+    # for each artist
+    response = table.query(
+        IndexName='IX_ARTISTS_ALBUMS',
+        ScanIndexForward=True,
+        KeyConditionExpression=Key('AA_PK').eq('ARTISTS'),
+        ProjectionExpression='PK, AA_SK'
+    )
 
-        #set FeatureSort = existing AC_SK
+    for item in response['Items']:
+        artist_id = item['PK']
+        print('checking artist {0}'.format(item['AA_SK']))
+        # get featured tracks
+        content = table.query(
+            IndexName='IX_ARTIST_CONTENT',
+            ScanIndexForward=True,
+            KeyConditionExpression=Key('AC_PK').eq(artist_id)
+        )
+        featured = list(filter(lambda i: bool(i.get('Featured', False)), content['Items']))
+        print('found {0} featured tracks'.format(len(featured)))
+        for track_item in featured:
+            if not 'FeatureSort' in track_item:
+                print('adding feature sort to {0}'.format(track_item['TrackTitle']))
+                #set FeatureSort = existing AC_SK
+                feature_sort = track_item['AC_SK']
+                content_sort = None
+                if not 'AA_PK' in track_item:
+                    print('setting single back to proper AC_SK')
+                    res = table.query(
+                            IndexName='IX_ARTIST_CONTENT',
+                            ScanIndexForward=True,
+                            KeyConditionExpression=Key('AC_PK').eq(
+                                artist_id) & Key('AC_SK').begins_with('3')
+                        )
+                    content_sort = '300'
+                    if len(res['Items']) > 0:
+                        last = res['Items'][-1]
+                        last_sort = int(last['AC_SK'])
+                        content_sort = str(last_sort + 1)
 
-        #if single, set AC_SK to 300 or ++ existing singles.
+            print('setting featuresort to {0} and content_sort to {1}'.format(feature_sort, content_sort))
+            update_exp = 'set FeatureSort = :feature_sort'
+            update_exp_vals = {
+                ':feature_sort': feature_sort
+            }
+            if content_sort is not None:
+                update_exp += ', AC_SK = :content_sort'
+                update_exp_vals[':content_sort'] = content_sort
+           
+            table.update_item(
+                Key = {'PK': track_item['PK'], 'SK': track_item['SK']},
+                UpdateExpression = update_exp,
+                ExpressionAttributeValues = update_exp_vals
+            )
 
-    pass

--- a/util/data_migrate.py
+++ b/util/data_migrate.py
@@ -40,3 +40,16 @@ def add_artist_normalized_names():
                 ReturnValues='UPDATED_NEW'
             )
         #print(res)
+
+
+def add_feature_sort():
+    
+    # get featured tracks
+
+    #if no FeatureSort attr
+
+        #set FeatureSort = existing AC_SK
+
+        #if single, set AC_SK to 300 or ++ existing singles.
+
+    pass


### PR DESCRIPTION
Using a new, separate attribute for sorting featured tracks.  Was previously using AC_SK (artist content sort), which is also used for singles.  This caused featured singles to not be listed in the admin section.  Now can have singles and featured managed separately.